### PR TITLE
add files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "git@github.com:newshipt/react-native-tachyons",
   "author": "Jeremy Dunn <jeremy@shipt.com> && Alan Kenyon <alan@shipt.com>",
   "license": "MIT",
+  "files": ["dist"],
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged",


### PR DESCRIPTION
We're currently publishing the entire project when we really only need to publish the `dist` folder generated by `yarn build`.